### PR TITLE
Update tutorial URL

### DIFF
--- a/_posts/2023-06-19_tutorial_url.md
+++ b/_posts/2023-06-19_tutorial_url.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: New URL for ESMValTool tutorial
+date: 2023-06-19
+---
+
+The ESMValTool tutorial is now also available at [https://tutorial.esmvaltool.org/](https://tutorial.esmvaltool.org/).

--- a/tutorial.md
+++ b/tutorial.md
@@ -4,4 +4,4 @@ title: Tutorial
 ---
 
 ![ESMValTool-logo](/assets/img/GitHub-Logo.png){:style="float: left;margin-right: 16px;margin-top: 16px;"}
-The ESMValTool tutorial is available at GitHub: [https://esmvalgroup.github.io/ESMValTool_Tutorial/](https://esmvalgroup.github.io/ESMValTool_Tutorial/)
+The ESMValTool tutorial is available at: [https://tutorial.esmvaltool.org/](https://tutorial.esmvaltool.org/)


### PR DESCRIPTION
This PR updates the URL of the tutorial to https://tutorial.esmvaltool.org and adds a post (2023-06-19) on this change.