### PR TITLE
Update Dowload section with short installation instructions.

### DIFF
--- a/download.md
+++ b/download.md
@@ -6,4 +6,13 @@ title: Download
 ## Download Earth System Model Evaluation Tool
 
 ![ESMValTool-logo](/assets/img/GitHub-Logo.png){:style="float: left;margin-right: 16px;margin-top: 16px;"}
+
 The ESMValTool is available at GitHub: [https://github.com/ESMValGroup/ESMValTool](https://github.com/ESMValGroup/ESMValTool)
+
+The ESMValTool is also available as a [conda-forge](https://conda-forge.org/) package. We recommend using [mamba](https://mamba.readthedocs.io/) as a package manager for your conda environments instead of [conda](https://docs.conda.io/projects/conda/en/stable/). Once you have installed the mamba package manager, you can install the entire ESMValTool package by running:
+
+```
+mamba create --name esmvaltool esmvaltool
+```
+
+Detailed installation instructions can be found in the [documentation](https://docs.esmvaltool.org/en/latest/quickstart/installation.html).


### PR DESCRIPTION
Closes #16

I wanted to keep it short, reuse instructions from the full installation guide and link to it for more details. The text is copied from fragments of the installation, as a way to summarize it. However, this means that it has to be maintained independently if the installation guide changes.