### PR TITLE
Add matomo page view tracking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -166,13 +166,10 @@ footer-hover-col: "#0085A1"
 # Google Tag Manager ID
 #gtm: ""
 
-# Matomo (aka Piwik) Web statistics
-# Uncomment the following section to enable Matomo. The opt-out parameter controls
-# whether or not you want to allow users to opt out of tracking.
-#matomo:
-#  site_id: "9"
-#  uri: "demo.wiki.pro"
-#  opt-out: true
+# Matomo Web statistics
+matomo:
+  site_id: "10"
+  uri: "matomo.research.software"
 
 # --- Comments --- #
 

--- a/_includes/matomo.html
+++ b/_includes/matomo.html
@@ -1,17 +1,21 @@
 {% if site.matomo %}
   <!-- Matomo -->
   <script type="text/javascript">
-    var _paq = _paq || [];
+    var _paq = window._paq = window._paq || [];
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setCookieDomain", "*.esmvaltool.org"]);
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
       var u="//{{- site.matomo.uri -}}/";
-      _paq.push(['setTrackerUrl', u+'piwik.php']);
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
       _paq.push(['setSiteId', '{{- site.matomo.site_id -}}']);
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
     })();
   </script>
-  <!-- End Piwik Code -->
+  <noscript><p><img referrerpolicy="no-referrer-when-downgrade" src="//{{- site.matomo.uri -}}/matomo.php?idsite={{- site.matomo.site_id -}}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+  <!-- End Matomo Code -->
 {% endif %}


### PR DESCRIPTION
<!--
    Thank you for contributing to the ESMValTool website!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on what changes to
    the ESMValTool website are introduced by this pull request.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Add Matomo page view tracking. This will allow us to report the number of users to demonstrate how relevant our software is to funders.

I've configured it without cookies and with respecting viewers who indicate they do not wish to be tracked for now.

Related to https://github.com/ESMValGroup/ESMValTool/issues/2520

Link to documentation:

***

## Before you get started

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValTool-website/issues) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review.

- [x] New functionality is working (e.g. links, images showing correctly, etc.)
- [x] Content is appropriate
- [x] Spelling and grammar are correct
- [x] All checks below this pull request were successful
