### PR TITLE
Fix links 03

### DIFF
--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -18,6 +18,7 @@ jobs:
           fail: true
           args: |
             './**/*.md'
+            --base-url https://esmvaltool.org/
             --max-concurrency 1
             --no-progress 
             --exclude-path 'meetings.md'

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -35,6 +35,7 @@ jobs:
           # './**/*.md' './**/*.html' './**/*.rst'
           args: >
             ./_site/**/*.html
+            --base-url https://esmvaltool.org/
             --max-concurrency 1 --no-progress 
             --accept '100..=103,200..=399, 429'
             --exclude https://doi.org/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,6 +1,12 @@
+# Browser automatically show /index.html instead of /index (lychee does not)
+/index
+
 # doi.org blocks bot requests
 https://doi.org/
 
 # error detected but working when accessed through browser:
 https://blog.esciencecenter.nl/easy-ipcc-powered-by-esmvalcore-19a0b6366ea7
 https://ai4pex.org/
+https://www.mdpi.com/
+https://essopenarchive.org/
+https://journals.ametsoc.org/

--- a/_config.yml
+++ b/_config.yml
@@ -267,6 +267,7 @@ exclude:
   - Gemfile.lock
   - LICENSE
   - README.md
+  - report.md
   - screenshot.png
   - docs/
   - vendor/

--- a/_posts/2023-12-20-New-release.md
+++ b/_posts/2023-12-20-New-release.md
@@ -39,6 +39,5 @@ Please refer to the Changelogs for an overview of the latest changes and additio
 
 -------------------
 
-Finally, a collection of output from 140 ESMValTool recipes run with version v2.10.0 is available on the [DKRZ portal](https://esmvaltool.dkrz.de/shared/esmvaltool/v2.10.0/). 
 
 Happy model evaluation with ESMValTool!


### PR DESCRIPTION
## Description
Most of the broken link report was due to an error in resolving the relative urls.
Adding `--base-url https://esmvaltool.org/` as argument to the link checker action fixed it.
The output of a manually triggered check for this branch can be found in #123.
Only remaining report is a time out, that also times out in the browser and might be temporary.
One broken link (to recipe outputs on dkrz that do not exist anymore) has been removed and 3 more journal website have been added to the ignore lists.


Closes #120 

***

## Before you get started

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValTool-website/issues) to discuss what you are going to do

## Checklist

It is the responsibility of the author to make sure the pull request is ready to review.

- [x] New functionality is working (e.g. links, images showing correctly, etc.)
- [x] Content is appropriate
- [x] Spelling and grammar are correct
- [x] All checks below this pull request were successful
